### PR TITLE
Update client.js to enable WS-A addressing

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -245,7 +245,7 @@ Client.prototype._invoke = function(method, args, location, callback, options, e
     this.wsdl.xmlnsInEnvelope + '>' +
     ((self.soapHeaders || self.security) ?
       (
-        "<" + envelopeKey + ":Header>" +
+        "<" + envelopeKey + ":Header  xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">" +
         (self.soapHeaders ? self.soapHeaders.join("\n") : "") +
         (self.security && !self.security.postProcess ? self.security.toXML() : "") +
         "</" + envelopeKey + ":Header>"


### PR DESCRIPTION
WS-A addreesing and soap headers needs to be added for soap services where client need to send WS-A headers. For e.g. http://bsestarmfdemo.bseindia.com/MFOrderEntry/MFOrder.svc?singleWsdl
